### PR TITLE
chore: exclude arm64 from unicorn until it can be made more pure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,8 @@ jobs:
         exclude:
           - flavor: registry1
             architecture: arm64
+          - flavor: unicorn
+            architecture: arm64
     uses: defenseunicorns/uds-common/.github/workflows/callable-publish.yaml@d59b1c601730bfa7ab76439643242358e529603e # v1.2.2
     with:
       flavor: ${{ matrix.flavor }}


### PR DESCRIPTION
## Description

Excludes arm64 for unicorn for now

## Related Issue

Fixes #N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Other (security config, docs update, etc)

## Checklist before merging

- [x] Test, docs, adr added or updated as needed
- [x] [Contributor Guide Steps](https://github.com/defenseunicorns/uds-package-sigstore/blob/main/CONTRIBUTING.md#developer-workflow) followed
